### PR TITLE
Silently skip code blocks without available code formatter

### DIFF
--- a/app/CodeFormatter/CodeFormatter.php
+++ b/app/CodeFormatter/CodeFormatter.php
@@ -26,24 +26,26 @@ abstract class CodeFormatter
 
     /**
      * @param string $code_language
-     * @return self
+     * @return self|null
      */
-    public static function create(string $code_language) : self
+    public static function create(string $code_language) : ?self
     {
         return self::getCodeFormatterForLanguage($code_language);
     }
 
      /**
      * @param string $lang
-     * @return self
+     * @return self|null
      */
-    protected static function getCodeFormatterForLanguage(string $lang) : self
+    protected static function getCodeFormatterForLanguage(string $lang) : ?self
     {
         foreach (self::$code_formatters as $code_formatter) {
             if (self::supportsLanguage($code_formatter, $lang)) {
                 return new $code_formatter;
             }
         }
+
+        return null;
     }
 
     /**

--- a/app/CodeFormatterApp.php
+++ b/app/CodeFormatterApp.php
@@ -74,7 +74,13 @@ class CodeFormatterApp
             if ($this->isCodeBlock($block)) {
                 $file = $this->putCodeInTempFile($key);
 
-                $this->executeCodeFormatting($file);
+                try {
+                    $this->executeCodeFormatting($file);
+                } catch (Exception $e) {
+                    $this->deleteTempCodeFile($file);
+
+                    continue;
+                }
 
                 $code = $this->getFormattedCode($file);
 
@@ -146,6 +152,10 @@ class CodeFormatterApp
     protected function executeCodeFormatting(string $file)
     {
         $code_formatter = CodeFormatter::create($this->code_language);
+
+        if (!$code_formatter) {
+            throw new Exception('No code formatter for given language found');
+        }
 
         $code_formatter->exec($file);
     }


### PR DESCRIPTION
This fixes a bug occurring when a post contains code blocks without an available code formatter.
This especially also applies to plain text code blocks without any explicitly defined programming language.
Thanks to this fix, such code blocks are simply skipped and do not get formatted.
Most importantly, no uncaught exception is thrown so that the formatting does not fail entirely.