### PR TITLE
Add C#, Java and Objective-C support in ClangCodeFormatter

### DIFF
--- a/app/CodeFormatter/ClangCodeFormatter.php
+++ b/app/CodeFormatter/ClangCodeFormatter.php
@@ -18,6 +18,9 @@ class ClangCodeFormatter extends CodeFormatter
     protected static $supported_languages = [
         'c',
         'cpp',
+        'cs',
+        'java',
+        'm',
     ];
 
     /**


### PR DESCRIPTION
This PR adds support for the following languages by making use of the already existing `ClangCodeFormatter`:
- C# (`.cs`)
- Java (`.java`)
- Objective-C (`.m`)