### PR TITLE
Avoid uniqid because it is not actually unique

### DIFF
--- a/app/CodeFormatterApp.php
+++ b/app/CodeFormatterApp.php
@@ -192,11 +192,11 @@ class CodeFormatterApp
      */
     protected function generateTempFileName(string $file_key)
     {
-        // generate sha256-hashed unique filename based on code content and key for specific part of post content
-        $filename = hash('sha256', $this->code_content . uniqid($file_key));
-        $file_extension = '.' . $this->code_language;
+        $filename = tempnam(__DIR__ . '/../storage/code', $file_key);
+        rename($filename, $filename .= '.' . $this->code_language);
+        @chmod($filename, 0666);
 
-        return __DIR__ . '/../storage/code/' . $filename . $file_extension;
+        return $filename;
     }
 
     /**


### PR DESCRIPTION
for reference:
https://www.php.net/manual/de/function.uniqid.php

uniqid() is based on time and uses a sleep() to avoid collisions in concurrent requests...
we can avoid this by using the better suited tempnam() function instead.

there are discussions to deprecate uniqid() in the php-community, so lets not rely on in.