### PR TITLE
Enable single quotes by default for Prettier-JS

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -36,6 +36,7 @@ overrides:
             - "*.javascript"
         options:
             parser: babel
+            singleQuote: true
             trailingComma: es5
             semi: true
 


### PR DESCRIPTION
See discussion in https://dev-community.de/threads/einfache-vs-doppelte-anführungszeichen-in-strings.190